### PR TITLE
fix: Passive Event Listener の例を wheel イベントに変更

### DIFF
--- a/src/js.md
+++ b/src/js.md
@@ -336,7 +336,7 @@ matchMedia(`(min-width: 768px)`).addEventListener('change', (media) => {
 ### Passive Event Listener を利用する
 
 ```js
-Element.addEventListener('scroll', onScroll, { passive: true });
+Element.addEventListener('wheel', onScroll, { passive: true });
 ```
 
 `passive`を有効にすると`preventDefault()`の呼び出しを待たずにリスナー関数を実行するため、その関数がブラウザの既定のアクション（たとえばスクロール）をブロックすることがなくなります。


### PR DESCRIPTION
Passive Event Listener による Scroll Junk の抑制に効果的なイベントは

* `touchstart`
* `touchmove`
* `wheel`
* `mousewheel`

です。仕様ではそれらのイベントはデフォルトで `passive: true` と定義されていて、現在 Safari の `wheel`, `mousewheel` イベントを除いて、仕様通りの実装となっています。

以上のことから Passive Event Listener の例は `wheel` が妥当だと考えます。

FYI: 
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners
https://dom.spec.whatwg.org/#default-passive-value