### PR TITLE
fix: bump yarn to 4.18.0 to fix TypeScript 7 compat patch failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
 		"vitepress": "1.6.4",
 		"vitepress-plugin-mermaid": "2.0.17"
 	},
-	"packageManager": "yarn@4.17.0",
+	"packageManager": "yarn@4.18.0",
 	"volta": {
 		"node": "24.18.0",
-		"yarn": "4.17.0"
+		"yarn": "4.18.0"
 	}
 }


### PR DESCRIPTION
## 背景

PR #468（typescript v7へのアップデート）が `renovate/artifacts` チェック失敗（yarn.lockの生成失敗）でブロックされていました。

```
Error: typescript@patch:typescript@npm%3A7.0.2#optional!builtin<compat/typescript>...
ENOENT: no such file or directory, lstat '/node_modules/typescript/lib/_tsc.js'
```

## 原因

Yarnには既知のPnP互換用ビルトインパッチ（`@yarnpkg/plugin-compat`）があり、typescriptパッケージに対して自動適用されます。このパッチはtypescript 6系までのレガシーな `lib/_tsc.js` レイアウトを前提としており、typescript v7（ネイティブ実装への移行に伴いパッケージ構造が刷新）に対して適用しようとするとハードエラーになります（[yarnpkg/berry#7191](https://github.com/yarnpkg/berry/issues/7191)）。

本リポジトリは `packageManager: "yarn@4.17.0"` に固定されていましたが、この問題は [yarnpkg/berry#7190](https://github.com/yarnpkg/berry/pull/7190) で修正され、**yarn 4.17.1** でリリース済みです。

## 対応

`packageManager` / `volta.yarn` を最新の **4.18.0** に更新しました（4.17.1以降の関連修正も含まれるバージョン）。

- ローカルで `yarn install`・`yarn build`・`yarn lint` が問題なく通ることを確認済みです。
- `yarn.lock` の内容に差分は発生しませんでした（依存解決結果は変わらないため）。

## 期待される効果

このPRがマージされ `dev` が更新されると、PR #468 は base branch との差分（コンフリクト）によりRenovateが自動的にartifactsを再生成し、typescript v7の解決パッチエラーが解消される見込みです。

## 関連

- PR #468: typescript v7へのアップデート（本修正で解消見込み）
- なお PR #469（mermaid v11.16.1 security patch）の `renovate/artifacts` 失敗は typescript を含まない別要因（corepackのyarnバイナリ取得時点のログのみで詳細エラーなし）のため、本修正で直接解消するとは限りません。念のため要観察です。