### PR TITLE
fix(renovate): pin platformAutomerge to false

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
 		":pinDevDependencies",
 		":semanticCommitTypeAll(chore)"
 	],
+	"platformAutomerge": false,
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true


### PR DESCRIPTION
## 背景

このリポジトリはブランチ保護（`dev`）で `required_approving_review_count: 2` を設定していますが、`bypass_pull_request_allowances` に Renovate app が登録されており、従来 Renovate は自前の direct マージ API を使ってレビュー要件をバイパスし自動マージしていました。

しかし、リポジトリ設定 `allow_auto_merge` を `false` から `true` に変更したところ、他リポジトリ（kamado, linters）での検証で、Renovate の挙動が GitHub native の auto-merge 予約方式に切り替わることが判明しました。native auto-merge 予約はブランチ保護の `bypass_pull_request_allowances` を評価せず、レビュー必須要件がそのまま適用されるため、CI が完全に成功しているPRであっても auto-merge 予約されたまま `mergeStateStatus: BLOCKED` の状態で永久に詰まる問題が発生します。このリポジトリでも同様の問題が起きる可能性が高いです。

## 対応内容

`allow_auto_merge` 有効化が bypass 機能と競合する問題を回避するため、`.github/renovate.json` に `"platformAutomerge": false` を明示的に追加し、`allow_auto_merge` の値に関わらず Renovate が常に自前の direct マージ API（bypass が効く方式）を使うように固定しました。

## 影響範囲

- 既存の `packageRules` 内の `automerge` 設定（minor/patch/pin/digest の自動マージ、lockFileMaintenance の自動マージ）はそのまま維持
- Renovate のマージ方式のみを明示的に固定するもので、automerge の対象範囲自体に変更はありません