### PR TITLE
chore: upgrade Node.js to v26

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24
+          node-version: 26
       - name: Install dependencies
         run: yarn install
       - name: Build Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24
+          node-version: 26
       - name: Enable Corepack and setup Yarn v4
         run: |
           corepack enable

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"packageManager": "yarn@4.18.0",
 	"volta": {
-		"node": "24.19.0",
+		"node": "26.7.0",
 		"yarn": "4.18.0"
 	}
 }


### PR DESCRIPTION
## Summary
- Volta の `node` ピンを 24.19.0 → 26.7.0 に更新
- CI (`test.yml` / `static.yml`) の `node-version` を 24 → 26 に更新

## Test plan
- [x] `yarn install` が Node.js v26.7.0 で成功することを確認
- [x] `yarn build` が成功することを確認